### PR TITLE
Wish list: new method Clear()

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,10 @@ HISTORY - release history for Tie::IxHash
 
 =over 8
 
+=item 1.23 (8 November 2010)
+
+New method Clear()
+
 =item 1.22  (27 February 2010)
 
 Build.PL added

--- a/lib/Tie/IxHash.pm
+++ b/lib/Tie/IxHash.pm
@@ -98,6 +98,15 @@ sub NEXTKEY {
 
 sub new { TIEHASH(@_) }
 
+sub Clear {
+  my $s = shift;
+  $s->[0] = {};   # hashkey index
+  $s->[1] = [];   # array of keys
+  $s->[2] = [];   # array of data
+  $s->[3] = 0;    # iter count
+  return;
+}
+
 #
 # add pairs to end of indexed hash
 # note that if a supplied key exists, it will not be reordered
@@ -554,6 +563,10 @@ Reorders the IxHash elements by textual comparison of the keys.
 =item SortByValue
 
 Reorders the IxHash elements by textual comparison of the values.
+
+=item Clear
+
+Resets the IxHash to its pristine state: with no elements at all.
 
 =back
 

--- a/t/ixhash.t
+++ b/t/ixhash.t
@@ -2,7 +2,7 @@
 use Tie::IxHash;
 
 my $TNUM = 0;
-print "1..25\n";
+print "1..26\n";
 
 sub T { print $_[0] ? "ok " : "not ok ", ++$TNUM, "\n" }
 my %bar;
@@ -54,4 +54,7 @@ $ixh->Pop;
 T 'z|7|o|2' eq join '|', %bar;
 $ixh->Splice($ixh->Length,0,$ixh->Pop);
 T 'z|7|o|2' eq join '|', %bar;
+
+$ixh->Clear;
+T $ixh->Length == 0;
 


### PR DESCRIPTION
This change adds a new method Clear() to Tie::IxHash objects.

The same can be obtained with

```
  $ixh->Delete($ixh->Keys);
```

(whose performance should be very poor)

or

```
  $ixh->Splice(0, $ixh->Length);
```

(whose performance should be better, but it is still quite complicate for the simple task of Clear())

Both options also include calling two methods on the object.
